### PR TITLE
feat: 로그인 시 유저 정보 반환하도록 기능 구현

### DIFF
--- a/src/docs/asciidoc/api/users/users.adoc
+++ b/src/docs/asciidoc/api/users/users.adoc
@@ -8,6 +8,12 @@ include::{snippets}/kakao-login-doc/request-body.adoc[]
 ==== HTTP Request
 include::{snippets}/user-login-doc/http-request.adoc[]
 
+==== HTTP Response
+include::{snippets}/user-login-doc/http-response.adoc[]
+include::{snippets}/user-login-doc/response-fields-data.adoc[]
+
+
+
 === 회원 가입
 ==== HTTP Request
 include::{snippets}/user-signUp-doc/http-request.adoc[]

--- a/src/main/java/yonseigolf/server/user/controller/UserController.java
+++ b/src/main/java/yonseigolf/server/user/controller/UserController.java
@@ -41,6 +41,7 @@ public class UserController {
         KakaoLoginResponse kakaoLoginResponse = oauthLoginService.processKakaoLogin(oauthToken.getAccessToken(), kakaoOauthInfo.getLoginUri());
 
         session.setAttribute("kakaoUser", kakaoLoginResponse.getId());
+
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse(
@@ -51,7 +52,7 @@ public class UserController {
     }
 
     @PostMapping("/users/signIn")
-    public ResponseEntity<CustomResponse> signIn(HttpSession session) {
+    public ResponseEntity<CustomResponse<SessionUser>> signIn(HttpSession session) {
         Long id = (Long) session.getAttribute("kakaoUser");
 
         SessionUser sessionUser = userService.signIn(id);
@@ -59,10 +60,11 @@ public class UserController {
 
         return ResponseEntity
                 .ok()
-                .body(new CustomResponse(
+                .body(new CustomResponse<>(
                         "success",
                         200,
-                        "로그인 성공"
+                        "로그인된 유저 정보 조회 성공",
+                        sessionUser
                 ));
     }
 
@@ -78,7 +80,7 @@ public class UserController {
             throw new IllegalArgumentException("[ERROR] 카카오 로그인을 먼저 해주세요.");
         }
 
-        SessionUser sessionUser = userService.signUp(request,kakaoId);
+        SessionUser sessionUser = userService.signUp(request, kakaoId);
 
         session.removeAttribute("kakaoUser");
         session.setAttribute("user", sessionUser);

--- a/src/main/java/yonseigolf/server/user/dto/response/SessionUser.java
+++ b/src/main/java/yonseigolf/server/user/dto/response/SessionUser.java
@@ -10,12 +10,14 @@ public class SessionUser {
 
     private long id;
     private String name;
+    private boolean adminStatus;
 
     public static SessionUser fromUser(User user) {
 
         return SessionUser.builder()
                 .id(user.getId())
                 .name(user.getName())
+                .adminStatus(true)
                 .build();
     }
 }

--- a/src/main/java/yonseigolf/server/user/service/UserService.java
+++ b/src/main/java/yonseigolf/server/user/service/UserService.java
@@ -26,8 +26,19 @@ public class UserService {
 
     public SessionUser signIn(Long kakaoId) {
 
-        User user = repository.findByKakaoId(kakaoId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        User user = findByKakaoId(kakaoId);
         return SessionUser.fromUser(user);
+    }
+
+    private User findById(Long id) {
+
+        return repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+    }
+
+    private User findByKakaoId(Long kakaoId) {
+
+        return repository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
     }
 }

--- a/src/test/java/yonseigolf/server/user/UserControllerTest.java
+++ b/src/test/java/yonseigolf/server/user/UserControllerTest.java
@@ -13,6 +13,7 @@ import yonseigolf.server.user.controller.UserController;
 import yonseigolf.server.user.dto.request.KakaoCode;
 import yonseigolf.server.user.dto.request.SignUpUserRequest;
 import yonseigolf.server.user.dto.response.KakaoLoginResponse;
+import yonseigolf.server.user.dto.response.SessionUser;
 import yonseigolf.server.user.dto.token.KakaoOauthInfo;
 import yonseigolf.server.user.dto.token.OauthToken;
 import yonseigolf.server.user.service.OauthLoginService;
@@ -21,8 +22,7 @@ import yonseigolf.server.user.service.UserService;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static yonseigolf.server.docs.utils.ApiDocumentUtils.getDocumentRequest;
@@ -84,8 +84,15 @@ public class UserControllerTest extends RestDocsSupport {
     void yonseiGolfLoginTest() throws Exception {
         // given
         MockHttpSession session = new MockHttpSession();
+        SessionUser user = SessionUser.builder()
+                .id(1L)
+                .name("name")
+                .adminStatus(true)
+                .build();
+        session.setAttribute("kakaoUser", 1L);
 
         // when
+        given(userService.signIn(1L)).willReturn(user); // userService mocking
 
         // then
         mockMvc.perform(post("/users/signIn")
@@ -94,8 +101,17 @@ public class UserControllerTest extends RestDocsSupport {
                 .andExpect(status().isOk())
                 .andDo(document("user-login-doc",
                         getDocumentRequest(),
-                        getDocumentResponse()
-                ));
+                        getDocumentResponse(),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("id").type(JsonFieldType.NUMBER)
+                                        .description("유저 id"),
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("유저 이름"),
+                                fieldWithPath("adminStatus").type(JsonFieldType.BOOLEAN)
+                                        .description("관리자 여부")))
+
+                );
     }
 
     @Test


### PR DESCRIPTION
- [x] #16 

api로 유저가 로그인 했는지 조회하도록 하는 것이 아닌, 로그인 하면 유저 정보를 반환하고, 클라이언트가 세션 스토리지에 저장할 수 있도록 변경 